### PR TITLE
refactor: replace to full url scheme

### DIFF
--- a/config/nvim/rc/ddc.toml
+++ b/config/nvim/rc/ddc.toml
@@ -1,15 +1,15 @@
 [[plugins]]
-repo = "Shougo/ddc.vim"
+repo = "https://github.com/Shougo/ddc.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/ddc.lua"
 on_source = "denops.vim"
 on_event = "InsertEnter"
 
 [[plugins]]
-repo = "Shougo/pum.vim"
+repo = "https://github.com/Shougo/pum.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/pum.lua"
 
 [[plugins]]
-repo = "Shougo/ddc-ui-pum"
+repo = "https://github.com/Shougo/ddc-ui-pum"
 on_source = "ddc.vim"
 depends = ["pum.vim"]
 
@@ -19,24 +19,24 @@ depends = ["pum.vim"]
 # hook_source =
 
 [[plugins]]
-repo = "shun/ddc-vim-lsp"
+repo = "https://github.com/shun/ddc-vim-lsp"
 depends = ["vim-lsp"]
 on_source = "ddc.vim"
 if = "!has('nvim')"
 
 [[plugins]]
-repo = "Shougo/ddc-source-lsp"
+repo = "https://github.com/Shougo/ddc-source-lsp"
 on_source = "ddc.vim"
 depends = ["nvim-lspconfig", "mason.nvim", "mason-lspconfig.nvim"]
 if = "has('nvim')"
 
 [[plugins]]
-repo = "uga-rosa/ddc-source-vsnip"
+repo = "https://github.com/uga-rosa/ddc-source-vsnip"
 on_source = "ddc.vim"
 depends = ["vim-vsnip"]
 
 [[plugins]]
-repo = "Shougo/ddc-source-line"
+repo = "https://github.com/Shougo/ddc-source-line"
 on_source = "ddc.vim"
 
 [[plugins]]
@@ -46,7 +46,7 @@ depends = "copilot.lua"
 if = "!exists('$COPILOT_DISABLE')"
 
 [[plugins]]
-repo = "Shougo/ddc-around"
+repo = "https://github.com/Shougo/ddc-around"
 on_source = "ddc.vim"
 
 # [[plugins]]
@@ -69,39 +69,39 @@ on_source = "ddc.vim"
 # on_source = 'ddc.vim'
 
 [[plugins]]
-repo = "Shougo/neco-vim"
+repo = "https://github.com/Shougo/neco-vim"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "matsui54/ddc-buffer"
+repo = "https://github.com/matsui54/ddc-buffer"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "Shougo/ddc-converter_remove_overlap"
+repo = "https://github.com/Shougo/ddc-converter_remove_overlap"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "Shougo/ddc-filter-converter_truncate_abbr"
+repo = "https://github.com/Shougo/ddc-filter-converter_truncate_abbr"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "delphinus/ddc-tmux"
+repo = "https://github.com/delphinus/ddc-tmux"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "tani/ddc-fuzzy"
+repo = "https://github.com/tani/ddc-fuzzy"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "LumaKernel/ddc-file"
+repo = "https://github.com/LumaKernel/ddc-file"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "Shougo/ddc-rg"
+repo = "https://github.com/Shougo/ddc-rg"
 on_source = "ddc.vim"
 
 [[plugins]]
-repo = "matsui54/denops-popup-preview.vim"
+repo = "https://github.com/matsui54/denops-popup-preview.vim"
 hook_source = """
 call popup_preview#enable()
 """
@@ -119,7 +119,7 @@ if = "!has('nvim')"
 # on_source = "ddc.vim"
 
 [[plugins]]
-repo = "uga-rosa/ddc-previewer-floating"
+repo = "https://github.com/uga-rosa/ddc-previewer-floating"
 on_source = "ddc.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/ddc-previewer-floating.lua"
 if = "has('nvim')"

--- a/config/nvim/rc/ddu.toml
+++ b/config/nvim/rc/ddu.toml
@@ -1,63 +1,63 @@
 [[plugins]]
-repo = "Shougo/ddu.vim"
+repo = "https://github.com/Shougo/ddu.vim"
 depends = "denops.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/ddu.lua"
 on_func = ["ddu#start"]
 on_map = { n = "<Plug>(ddu" }
 
 [[plugins]]
-repo = "Shougo/ddu-ui-ff"
+repo = "https://github.com/Shougo/ddu-ui-ff"
 on_source = "ddu.vim"
 # hooks_file = "$DEIN_RC_DIR/hooks/ddu-ui-ff.lua"
 hooks_file = "$DEIN_RC_DIR/hooks/ddu-ui-ff.vim"
 
 [[plugins]]
-repo = "Shougo/ddu-source-file_rec"
+repo = "https://github.com/Shougo/ddu-source-file_rec"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "shun/ddu-source-rg"
+repo = "https://github.com/shun/ddu-source-rg"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "kuuote/ddu-source-mr"
+repo = "https://github.com/kuuote/ddu-source-mr"
 on_source = "ddu.vim"
 depends = ["vim-mr"]
 
 [[plugins]]
-repo = "lambdalisue/vim-mr"
+repo = "https://github.com/lambdalisue/vim-mr"
 on_func = ["mr#mru#list", "mr#mrr#list", "mr#mrw#list"]
 
 [[plugins]]
-repo = "shun/ddu-source-buffer"
+repo = "https://github.com/shun/ddu-source-buffer"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "liquidz/ddu-source-custom-list"
+repo = "https://github.com/liquidz/ddu-source-custom-list"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "matsui54/ddu-source-file_external"
+repo = "https://github.com/matsui54/ddu-source-file_external"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "uga-rosa/ddu-source-lsp"
+repo = "https://github.com/uga-rosa/ddu-source-lsp"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "Shougo/ddu-filter-converter_display_word"
+repo = "https://github.com/Shougo/ddu-filter-converter_display_word"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "Shougo/ddu-filter-matcher_substring"
+repo = "https://github.com/Shougo/ddu-filter-matcher_substring"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "yuki-yano/ddu-filter-fzf"
+repo = "https://github.com/yuki-yano/ddu-filter-fzf"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "Shougo/ddu-kind-file"
+repo = "https://github.com/Shougo/ddu-kind-file"
 on_source = "ddu.vim"
 
 # [[plugins]]
@@ -66,13 +66,13 @@ on_source = "ddu.vim"
 # on_source = "denops.vim"
 
 [[plugins]]
-repo = "Omochice/ddu-source-anyjump"
+repo = "https://github.com/Omochice/ddu-source-anyjump"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "Omochice/ddu-source-redmine"
+repo = "https://github.com/Omochice/ddu-source-redmine"
 on_source = "ddu.vim"
 
 [[plugins]]
-repo = "Shougo/ddu-source-action"
+repo = "https://github.com/Shougo/ddu-source-action"
 on_source = "ddu.vim"

--- a/config/nvim/rc/dein.toml
+++ b/config/nvim/rc/dein.toml
@@ -60,13 +60,13 @@ endif
 """
 
 [[plugins]]
-repo = "Shougo/dein.vim"
+repo = "https://github.com/Shougo/dein.vim"
 
 [[plugins]]
-repo = "tani/vim-artemis"
+repo = "https://github.com/tani/vim-artemis"
 
 [[plugins]]
-repo = "sainnhe/sonokai"
+repo = "https://github.com/sainnhe/sonokai"
 hook_add = """
 let g:sonokai_style = 'espresso'
 let g:sonokai_dim_inactive_windows = v:false
@@ -76,7 +76,7 @@ let g:sonokai_transparent_background = v:true
 """
 
 [[plugins]]
-repo = "catppuccin/vim"
+repo = "https://github.com/catppuccin/vim"
 name = "catpuccin"
 hook_add = """
 augroup erace-cursorline
@@ -86,15 +86,15 @@ augroup END
 """
 
 [[plugins]]
-repo = "itchyny/lightline.vim"
+repo = "https://github.com/itchyny/lightline.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/lightline.lua"
 depends = ["vim-nerdfont", 'vim-gitbranch']
 
 [[plugins]]
-repo = "itchyny/vim-gitbranch"
+repo = "https://github.com/itchyny/vim-gitbranch"
 
 [[plugins]]
-repo = "vim-jp/vimdoc-ja"
+repo = "https://github.com/vim-jp/vimdoc-ja"
 hook_add = """
 if has('nvim')
   set helplang=en " default
@@ -104,16 +104,16 @@ endif
 """
 
 [[plugins]]
-repo = "lambdalisue/vim-nerdfont"
+repo = "https://github.com/lambdalisue/vim-nerdfont"
 
 [[plugins]]
-repo = "lambdalisue/vim-seethrough"
+repo = "https://github.com/lambdalisue/vim-seethrough"
 hook_add = """
 let g:seethrough_disabled = has('gui_running')
 """
 
 [[plugins]]
-repo = "mattn/vim-findroot"
+repo = "https://github.com/mattn/vim-findroot"
 hook_add = """
 let g:findroot_not_for_subdir = v:false
 let g:findroot_patterns = ['.git/', 'settings.gradle']
@@ -123,7 +123,7 @@ let g:findroot_patterns = ['.git/', 'settings.gradle']
 # repo = "vim-jp/vim-streem"
 
 [[plugins]]
-repo = "vim-scripts/fish.vim"
+repo = "https://github.com/vim-scripts/fish.vim"
 
 # [[plugins]]
 # repo = "mityu/vim-applescript"
@@ -132,10 +132,10 @@ repo = "vim-scripts/fish.vim"
 repo = "https://github.com/elkasztano/nushell-syntax-vim"
 
 [[plugins]]
-repo = "Shougo/shougo-s-github"
+repo = "https://github.com/Shougo/shougo-s-github"
 if = 0
 
 [[plugins]]
-repo = "kuuote/dotvim"
+repo = "https://github.com/kuuote/dotvim"
 if = 0
 

--- a/config/nvim/rc/dein_asyncomplete.toml
+++ b/config/nvim/rc/dein_asyncomplete.toml
@@ -1,9 +1,9 @@
 [[plugins]]
-repo = "hrsh7th/vim-vsnip-integ"
+repo = "https://github.com/hrsh7th/vim-vsnip-integ"
 on_source = "vim-vsnip"
 
 [[plugins]]
-repo = "prabirshrestha/asyncomplete.vim"
+repo = "https://github.com/prabirshrestha/asyncomplete.vim"
 hook_source = """
 imap <C-Space> <Plug>(asyncomplete_force_refresh)
 let g:asyncomplete_auto_completeopt = v:true
@@ -34,16 +34,16 @@ call asyncomplete#register_source(
 on_event = "InsertEnter"
 
 [[plugins]]
-repo = "prabirshrestha/asyncomplete-buffer.vim"
+repo = "https://github.com/prabirshrestha/asyncomplete-buffer.vim"
 on_source = "asyncomplete.vim"
 
 [[plugins]]
-repo = "prabirshrestha/asyncomplete-lsp.vim"
+repo = "https://github.com/prabirshrestha/asyncomplete-lsp.vim"
 on_source = "asyncomplete.vim"
 depends = "vim-lsp"
 
 [[plugins]]
-repo = "prabirshrestha/asyncomplete-file.vim"
+repo = "https://github.com/prabirshrestha/asyncomplete-file.vim"
 on_source = "asyncomplete.vim"
 depends = "asyncomplete.vim"
 

--- a/config/nvim/rc/dein_colors.toml
+++ b/config/nvim/rc/dein_colors.toml
@@ -1,9 +1,9 @@
 [[plugins]]
-repo = "EdenEast/nightfox.nvim"
+repo = "https://github.com/EdenEast/nightfox.nvim"
 on_func = "ChangeColor"
 
 [[plugins]]
-repo = "ayu-theme/ayu-vim"
+repo = "https://github.com/ayu-theme/ayu-vim"
 hook_add = """
 let g:ayucolor = 'dark'
 """
@@ -14,11 +14,11 @@ repo = 'Mangeshrex/uwu.vim'
 on_func = "ChangeColor"
 
 [[plugins]]
-repo = "yasukotelin/shirotelin"
+repo = "https://github.com/yasukotelin/shirotelin"
 on_func = "ChangeColor"
 
 [[plugins]]
-repo = "haishanh/night-owl.vim"
+repo = "https://github.com/haishanh/night-owl.vim"
 hook_add = """
 let g:colors_map['nightowl'] = 'night-owl'
 """

--- a/config/nvim/rc/dein_denops.toml
+++ b/config/nvim/rc/dein_denops.toml
@@ -1,5 +1,5 @@
 [[plugins]]
-repo = "vim-denops/denops.vim"
+repo = "https://github.com/vim-denops/denops.vim"
 hook_add = """
 command! DenopsRestart call denops#server#restart() " NOTE: not work?
 """
@@ -11,7 +11,7 @@ on_event = "CursorHold"
 # on_source = "denops.vim"
 #
 [[plugins]]
-repo = "Omochice/dps-paiza-io-vim"
+repo = "https://github.com/Omochice/dps-paiza-io-vim"
 # repo = "~/workspace/dps-paiza-io-vim"
 on_cmd = "PaizaIO"
 
@@ -21,7 +21,7 @@ on_cmd = "PaizaIO"
 # on_cmd = "CharCount"
 
 [[plugins]]
-repo = "Omochice/dps-codic-vim"
+repo = "https://github.com/Omochice/dps-codic-vim"
 # repo = "~/workspace/dps-codic-vim"
 on_cmd = "Codic"
 
@@ -48,7 +48,7 @@ on_cmd = "Codic"
 # # on_event = "BufRead"
 #
 [[plugins]]
-repo = "gamoutatsumi/dps-ghosttext.vim"
+repo = "https://github.com/gamoutatsumi/dps-ghosttext.vim"
 lua_add = """
 local vimx = require("artemis")
 vimx.g["dps_ghosttext#ftmap"] = {
@@ -68,13 +68,13 @@ depends = "denops.vim"
 on_cmd = "GhostStart"
 
 [[plugins]]
-repo = "lambdalisue/vim-gin"
+repo = "https://github.com/lambdalisue/vim-gin"
 depends = "denops.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/gin.lua"
 on_cmd = ["Gin", "GinStatus"]
 
 [[plugins]]
-repo = "Omochice/tataku.vim"
+repo = "https://github.com/Omochice/tataku.vim"
 # repo = "~/Toy/tataku.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/tataku.lua"
 depends = ["denops.vim", "vim-operator-user"]
@@ -83,50 +83,50 @@ on_map = { n = "<Plug>(operator-tataku", x = "<Plug>(operator-tataku" }
 
 [[plugins]]
 # repo = "~/Toy/tataku-collector-current_line"
-repo = "Omochice/tataku-collector-current_line"
+repo = "https://github.com/Omochice/tataku-collector-current_line"
 on_source = "tataku.vim"
 
 [[plugins]]
 # repo = "~/Toy/tataku-processor-google_translate"
-repo = "Omochice/tataku-processor-google_translate"
+repo = "https://github.com/Omochice/tataku-processor-google_translate"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-processor-intl_segmenter"
+repo = "https://github.com/Omochice/tataku-processor-intl_segmenter"
 # repo = "~/Toy/tataku-processor-intl_segmenter"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-emitter-nvim_floatwin"
+repo = "https://github.com/Omochice/tataku-emitter-nvim_floatwin"
 # repo = "~/Toy/tataku-emitter-nvim_floatwin"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-processor-split_by_displaywidth"
+repo = "https://github.com/Omochice/tataku-processor-split_by_displaywidth"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-processor-ollama"
+repo = "https://github.com/Omochice/tataku-processor-ollama"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-emitter-window"
+repo = "https://github.com/Omochice/tataku-emitter-window"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-emitter-echo"
+repo = "https://github.com/Omochice/tataku-emitter-echo"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-collector-buffer"
+repo = "https://github.com/Omochice/tataku-collector-buffer"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "Omochice/tataku-processor-eta"
+repo = "https://github.com/Omochice/tataku-processor-eta"
 on_source = "tataku.vim"
 
 [[plugins]]
-repo = "4513ECHO/denops-gitter.vim"
+repo = "https://github.com/4513ECHO/denops-gitter.vim"
 hook_add = """
 let g:gitter#token = $GITTER_TOKEN
 command! ReadingVimrcGitter tabnew gitter://room/vim-jp/reading-vimrc

--- a/config/nvim/rc/dein_lazy.toml
+++ b/config/nvim/rc/dein_lazy.toml
@@ -1,8 +1,8 @@
 [[plugins]]
-repo = "kana/vim-textobj-user"
+repo = "https://github.com/kana/vim-textobj-user"
 
 [[plugins]]
-repo = "kana/vim-textobj-line"
+repo = "https://github.com/kana/vim-textobj-line"
 depends = "vim-textobj-user"
 lua_add = """
 local vimx = require("artemis")
@@ -12,7 +12,7 @@ vimx.keymap.set({ "x", "o" }, "il", "<Plug>(textobj-line-i)")
 on_map = { x = "<Plug>", o = "<Plug>" }
 
 [[plugins]]
-repo = "thinca/vim-textobj-between"
+repo = "https://github.com/thinca/vim-textobj-between"
 depends = ["vim-textobj-user"]
 lua_add = """
 local vimx = require("artemis")
@@ -22,7 +22,7 @@ vimx.keymap.set({ "x", "o" }, "if", "<Plug>(textobj-between-i)")
 on_map = { x = "<Plug>", o = "<Plug>" }
 
 [[plugins]]
-repo = "kana/vim-textobj-fold"
+repo = "https://github.com/kana/vim-textobj-fold"
 lua_add = """
 local vimx = require("artemis")
 vimx.keymap.set({ "x", "o" }, "az", "<Plug>(textobj-fold-a)")
@@ -32,7 +32,7 @@ depends = ["vim-textobj-user"]
 on_map = { x = "<Plug>", o = "<Plug>" }
 
 [[plugins]]
-repo = "Omochice/vim-textobj-codeblock"
+repo = "https://github.com/Omochice/vim-textobj-codeblock"
 depends = ["vim-textobj-user"]
 lua_add = '''
 local vimx = require("artemis")
@@ -43,7 +43,7 @@ vimx.keymap.set({ "x", "o" }, "ic", "<Plug>(textobj-codeblock-i)")
 on_map = { x = "<Plug>", o = "<Plug>" }
 
 [[plugins]]
-repo = "Omochice/vim-textobj-bettertag"
+repo = "https://github.com/Omochice/vim-textobj-bettertag"
 lua_add = """
 require("artemis").keymap.set({ "x", "o" }, "it", "<Plug>(textobj-bettertag-i)")
 """
@@ -51,7 +51,7 @@ on_map = { x = "<Plug>", o = "<Plug>" }
 depends = ["vim-textobj-user"]
 
 [[plugins]]
-repo = "kana/vim-textobj-indent"
+repo = "https://github.com/kana/vim-textobj-indent"
 depends = ["vim-textobj-user"]
 lua_add = """
 local vimx = require("artemis")
@@ -61,13 +61,13 @@ vimx.keymap.set({ "x", "o" }, "ii", "<Plug>(textobj-indent-i)")
 on_map = { x = "<Plug>", o = "<Plug>" }
 
 [[plugins]]
-repo = "kana/vim-operator-user"
+repo = "https://github.com/kana/vim-operator-user"
 
 [[plugins]]
-repo = "kana/vim-repeat"
+repo = "https://github.com/kana/vim-repeat"
 
 [[plugins]]
-repo = "easymotion/vim-easymotion"
+repo = "https://github.com/easymotion/vim-easymotion"
 hook_add = """
 nmap <Space>j <Plug>(easymotion-j)
 nmap <Space>k <Plug>(easymotion-k)
@@ -79,12 +79,12 @@ let g:EasyMotion_use_smartsign_jp = v:true
 on_map = { n = "<Plug>" }
 
 [[plugins]]
-repo = "hrsh7th/vim-searchx"
+repo = "https://github.com/hrsh7th/vim-searchx"
 hooks_file = "$DEIN_RC_DIR/hooks/searchx.lua"
 on_func = "searchx"
 
 [[plugins]]
-repo = "haya14busa/vim-asterisk"
+repo = "https://github.com/haya14busa/vim-asterisk"
 hook_add = """
 nmap * <Plug>(asterisk-z*)
 xmap * <Plug>(asterisk-z*)
@@ -92,14 +92,14 @@ xmap * <Plug>(asterisk-z*)
 on_map = { n = "<Plug>" }
 
 [[plugins]]
-repo = "hrsh7th/vim-vsnip"
+repo = "https://github.com/hrsh7th/vim-vsnip"
 hooks_file = "$DEIN_RC_DIR/hooks/vsnip.lua"
 on_map = { x = "<Plug>", i = "<Plug>" }
 depends = ["lexima.vim"] # Need this for control order to sourcing
 on_event = "InsertEnter"
 
 [[plugins]]
-repo = "cohama/lexima.vim"
+repo = "https://github.com/cohama/lexima.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/lexima.lua"
 on_event = "InsertEnter"
 
@@ -112,20 +112,20 @@ on_event = "InsertEnter"
 # """
 
 [[plugins]]
-repo = "prabirshrestha/vim-lsp"
+repo = "https://github.com/prabirshrestha/vim-lsp"
 hooks_file = ["$DEIN_RC_DIR/hooks/vim-lsp.lua", "$DEIN_RC_DIR/hooks/vim-lsp.vim"]
 on_event = ["BufRead", "BufNewFile"]
 if = "!has('nvim')"
 
 [[plugins]]
-repo = "mattn/vim-lsp-settings"
+repo = "https://github.com/mattn/vim-lsp-settings"
 hook_add = """
 let g:lsp_settings_enable_suggestions = v:false
 """
 on_source = "vim-lsp"
 
 [[plugins]]
-repo = "neovim/nvim-lspconfig"
+repo = "https://github.com/neovim/nvim-lspconfig"
 on_lua = "lspconfig"
 if = "has('nvim')"
 
@@ -135,18 +135,18 @@ on_source = "nvim-lspconfig"
 hooks_file = "$DEIN_RC_DIR/hooks/nvim-navic.lua"
 
 [[plugins]]
-repo = "williamboman/mason.nvim"
+repo = "https://github.com/williamboman/mason.nvim"
 on_lua = "mason"
 if = "has('nvim')"
 
 [[plugins]]
-repo = "williamboman/mason-lspconfig.nvim"
+repo = "https://github.com/williamboman/mason-lspconfig.nvim"
 on_event = ["BufRead", "BufNewFile"]
 hooks_file = "$DEIN_RC_DIR/hooks/mason-lspconfig.lua"
 if = "has('nvim')"
 
 [[plugins]]
-repo = "machakann/vim-sandwich"
+repo = "https://github.com/machakann/vim-sandwich"
 hooks_file = "$DEIN_RC_DIR/hooks/sandwich.lua"
 depends = "vim-textobj-user"
 [plugins.on_map]
@@ -155,7 +155,7 @@ x = ["<Plug>", "<Plug>(textobj-sandwich"]
 o = "<Plug>(textobj-sandwich"
 
 [[plugins]]
-repo = "uga-rosa/contextment.vim"
+repo = "https://github.com/uga-rosa/contextment.vim"
 # repo = "~/Toy/contextment.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/contextment.lua"
 depends = ["context_filetype.vim"]
@@ -163,11 +163,11 @@ on_map = { nxo = "<Plug>" }
 if = "!has('nvim')"
 
 [[plugins]]
-repo = "markonm/traces.vim"
+repo = "https://github.com/markonm/traces.vim"
 on_event = "CmdlineEnter"
 
 [[plugins]]
-repo = "liuchengxu/vista.vim"
+repo = "https://github.com/liuchengxu/vista.vim"
 depends = ["vim-lsp"]
 on_cmd = "Vista"
 hook_add = """
@@ -175,7 +175,7 @@ let g:vista_default_executive = has('nvim') ? 'nvim_lsp' : 'vim_lsp'
 """
 
 [[plugins]]
-repo = "simeji/winresizer"
+repo = "https://github.com/simeji/winresizer"
 hook_add = """
 function s:number_of_non_float() abort
   " on floating / popup window is return 'popup'.
@@ -197,14 +197,14 @@ let g:winresizer_vert_resize = 3
 on_cmd = ["WinResizerStartResize", "WinResizerStartFocus"]
 
 [[plugins]]
-repo = "thinca/vim-quickrun"
+repo = "https://github.com/thinca/vim-quickrun"
 depends = ["vim-quickrun-neovim-job"]
 hooks_file = "$DEIN_RC_DIR/hooks/quickrun.lua"
 on_map = { n = "<Plug>" }
 on_cmd = ["QuickRun"]
 
 [[plugins]]
-repo = "lambdalisue/vim-quickrun-neovim-job"
+repo = "https://github.com/lambdalisue/vim-quickrun-neovim-job"
 on_source = "vim-quickrun"
 
 # [[plugins]]
@@ -216,7 +216,7 @@ on_source = "vim-quickrun"
 # on_cmd = "TeXOutline"
 
 [[plugins]]
-repo = "ntpeters/vim-better-whitespace"
+repo = "https://github.com/ntpeters/vim-better-whitespace"
 hook_add = """
 let g:better_whitespace_enabled = !has('nvim')
 let g:strip_whitespace_on_save = v:false
@@ -224,7 +224,7 @@ let g:strip_whitespace_on_save = v:false
 on_cmd = ["StripWhitespace", "StripWhitespaceOnChangedLines"]
 
 [[plugins]]
-repo = "heavenshell/vim-pydocstring"
+repo = "https://github.com/heavenshell/vim-pydocstring"
 build = "make install"
 hook_add = """
 let g:pydocstring_formatter = 'google'
@@ -232,11 +232,11 @@ let g:pydocstring_formatter = 'google'
 on_cmd = ["Pydocstring", "PydocstringFormat"]
 
 [[plugins]]
-repo = "mattn/vim-maketable"
+repo = "https://github.com/mattn/vim-maketable"
 on_cmd = "MakeTable"
 
 [[plugins]]
-repo = "previm/previm"
+repo = "https://github.com/previm/previm"
 on_cmd = "PrevimOpen"
 hook_add = """
 let g:previm_wsl_mode = has('wsl')
@@ -245,25 +245,25 @@ let g:previm_show_header = v:false
 depends = ["open-browser.vim"]
 
 [[plugins]]
-repo = "tyru/open-browser.vim"
+repo = "https://github.com/tyru/open-browser.vim"
 hook_add = """
 nmap gx <Plug>(openbrowser-open)
 """
 on_map = { n = "<Plug>(openbrowser" }
 
 [[plugins]]
-repo = "ap/vim-css-color"
+repo = "https://github.com/ap/vim-css-color"
 on_ft = ["css", "scss", "vue"]
 
 [[plugins]]
-repo = "pechorin/any-jump.vim"
+repo = "https://github.com/pechorin/any-jump.vim"
 hook_add = """
 let g:any_jump_disable_default_keybindings = v:true
 """
 on_cmd = ["AnyJump", "AnyJumpVisual", "AnyJumpBack", "AnyJumpLastResults"]
 
 [[plugins]]
-repo = "y0za/vim-reading-vimrc"
+repo = "https://github.com/y0za/vim-reading-vimrc"
 on_cmd = ["ReadingVimrcNext", "ReadingVimrcList", "ReadingVimrcLoad", "ReadingVimrcCopy"]
 hook_source = """
 function! s:reading_copy(line1, line2) abort
@@ -280,14 +280,14 @@ command! -range ReadingVimrcCopy call <SID>reading_copy(<line1>, <line2>)
 """
 
 [[plugins]]
-repo = "lambdalisue/vim-suda"
+repo = "https://github.com/lambdalisue/vim-suda"
 hook_add = """
 let g:suda_smart_edit = v:true
 """
 on_event = "BufRead"
 
 [[plugins]]
-repo = "Shougo/context_filetype.vim"
+repo = "https://github.com/Shougo/context_filetype.vim"
 lua_source = """
 local vimx = require("artemis")
 vimx.g["context_filetype#ignore_patterns"] = {
@@ -296,23 +296,23 @@ vimx.g["context_filetype#ignore_patterns"] = {
 """
 
 [[plugins]]
-repo = "nvim-treesitter/nvim-treesitter"
+repo = "https://github.com/nvim-treesitter/nvim-treesitter"
 if = "has('nvim')"
 on_event = ["BufRead", "BufNewFile"]
 hook_post_update = "TSUpdate"
 hooks_file = "$DEIN_RC_DIR/hooks/treesitter.lua"
 
 [[plugins]]
-repo = "nvim-treesitter/playground"
+repo = "https://github.com/nvim-treesitter/playground"
 on_source = "nvim-treesitter"
 
 [[plugins]]
-repo = "nvim-treesitter/nvim-treesitter-textobjects"
+repo = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects"
 on_source = "nvim-treesitter"
 # Use upper case for treesitter, it prevent to confuse at Vim's one.
 
 [[plugins]]
-repo = "nvim-treesitter/nvim-treesitter-context"
+repo = "https://github.com/nvim-treesitter/nvim-treesitter-context"
 # TODO: i wait to show context on top-right position
 # TODO: show context like A>B>C
 on_source = "nvim-treesitter"
@@ -337,7 +337,7 @@ require("treesitter-context").setup({
 if = false
 
 [[plugins]]
-repo = "Omochice/nvim-tree-docs"
+repo = "https://github.com/Omochice/nvim-tree-docs"
 on_source = "nvim-treesitter"
 lua_source = """
 require("nvim-treesitter.configs").setup({
@@ -348,7 +348,7 @@ require("nvim-treesitter.configs").setup({
 """
 
 [[plugins]]
-repo = "yuki-yano/vim-operator-replace"
+repo = "https://github.com/yuki-yano/vim-operator-replace"
 depends = "vim-operator-user"
 on_map = { n = "<Plug>", x = "<Plug>" }
 hook_add = """
@@ -357,7 +357,7 @@ xmap R <Plug>(operator-replace)
 """
 
 [[plugins]]
-repo = "mattn/vim-treesitter"
+repo = "https://github.com/mattn/vim-treesitter"
 build = "cd server && go build"
 if = "!has('nvim')"
 
@@ -395,7 +395,7 @@ if = "!has('nvim')"
 # if = "has('wsl')"
 
 [[plugins]]
-repo = "machakann/vim-vimhelplint"
+repo = "https://github.com/machakann/vim-vimhelplint"
 on_cmd = ["VimhelpLint"]
 [plugins.ftplugin]
 help = """
@@ -403,7 +403,7 @@ nnoremap <silent><buffer><Space>d <Cmd>VimhelpLint!<CR>
 """
 
 [[plugins]]
-repo = "mattn/vim-sonictemplate"
+repo = "https://github.com/mattn/vim-sonictemplate"
 on_cmd = ["Template"]
 hook_add = """
 let g:sonictemplate_vim_template_dir = g:config_dir .. '/templates'
@@ -415,7 +415,7 @@ nnoremap <Plug>(fzf-p-prefix)t <Cmd>call fzf#sonictemplate#run()<CR>
 """
 
 [[plugins]]
-repo = "pappasam/vim-filetype-formatter"
+repo = "https://github.com/pappasam/vim-filetype-formatter"
 lua_add = """
 local vimx = require('artemis')
 vimx.g.vim_filetype_formatter_commands = {
@@ -451,7 +451,7 @@ elm = "nnoremap <buffer><Space>f <Cmd>FiletypeFormat<CR>"
 dockerfile = "nnoremap <buffer><Space>f <Cmd>FiletypeFormat<CR>"
 
 [[plugins]]
-repo = "voldikss/vim-floaterm"
+repo = "https://github.com/voldikss/vim-floaterm"
 hook_add = """
 command! Lazygit FloatermNew --autoclose=2 --autohide=0 --opener=tabe --height=1.0 --width=1.0 --title=lazygit lazygit
 command! Ranger FloatermNew --autoclose=2 --autohide=0 --opener=tabe --height=1.0 --width=1.0 --title=ranger ranger
@@ -468,18 +468,18 @@ on_cmd = ["FloatermNew"]
 floaterm = "tnoremap <buffer> <ESC> <ESC>"
 
 [[plugins]]
-repo = "vim-jp/vital.vim"
+repo = "https://github.com/vim-jp/vital.vim"
 on_cmd = ["Vitalize"]
 
 [[plugins]]
-repo = "thinca/vim-partedit"
+repo = "https://github.com/thinca/vim-partedit"
 hook_add = """
 let g:partedit#opener = 'vsplit'
 """
 on_func = ["partedit#start"]
 
 [[plugins]]
-repo = "Omochice/vim-operator-partedit"
+repo = "https://github.com/Omochice/vim-operator-partedit"
 depends = ["vim-operator-user", "vim-partedit"]
 hook_add = """
 nmap qe <Plug>(operator-partedit-start)
@@ -493,16 +493,16 @@ xmap <buffer> qe <Plug>(operator-partedit-codeblock)
 """
 
 [[plugins]]
-repo = "lambdalisue/vim-fern"
+repo = "https://github.com/lambdalisue/vim-fern"
 hooks_file = "$DEIN_RC_DIR/hooks/fern.lua"
 on_cmd = "Fern"
 
 [[plugins]]
-repo = "lambdalisue/fern-hijack.vim"
+repo = "https://github.com/lambdalisue/fern-hijack.vim"
 on_source = "fern.vim"
 
 [[plugins]]
-repo = "lambdalisue/fern-renderer-nerdfont.vim"
+repo = "https://github.com/lambdalisue/fern-renderer-nerdfont.vim"
 hook_add = """
 let g:fern#renderer = "nerdfont"
 let g:fern#renderer#nerdfont#indent_markers = 1
@@ -510,13 +510,13 @@ let g:fern#renderer#nerdfont#indent_markers = 1
 on_source = "fern.vim"
 
 [[plugins]]
-repo = "mattn/emmet-vim"
+repo = "https://github.com/mattn/emmet-vim"
 hooks_file = "$DEIN_RC_DIR/hooks/emmet.lua"
 on_map = { i = "<Plug>" }
 
 [[plugins]]
 # repo = "~/Toy/toy-postfix.vim"
-repo = "Omochice/toy-postfix.vim"
+repo = "https://github.com/Omochice/toy-postfix.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/toy-postfix.lua"
 on_func = ["toy_postfix#expandable", "toy_postfix#expand"]
 
@@ -537,7 +537,7 @@ inoremap <expr><C-j> "\<C-g>u" .. <SID>expand_snippets()
 """
 
 [[plugins]]
-repo = "Omochice/yank-remote-url.vim"
+repo = "https://github.com/Omochice/yank-remote-url.vim"
 # repo = "~/Toy/yank-remote-url.vim"
 hook_add = """
 let g:yank_remote_url#enable_cache = v:true
@@ -549,11 +549,11 @@ nnoremap <Space>gy <Cmd>YankRemoteURL<CR>
 on_cmd = "YankRemoteURL"
 
 [[plugins]]
-repo = "tweekmonster/helpful.vim"
+repo = "https://github.com/tweekmonster/helpful.vim"
 on_cmd = "HelpfulVersion"
 
 [[plugins]]
-repo = "rhysd/git-messenger.vim"
+repo = "https://github.com/rhysd/git-messenger.vim"
 lua_add = """
 local vimx = require('artemis')
 vimx.g.git_messenger_no_default_mappings = false
@@ -563,31 +563,31 @@ vimx.keymap.set('n', '<Space>gm', '<Plug>(git-messenger)')
 on_map = { n = "<Plug>" }
 
 [[plugins]]
-repo = "tyru/capture.vim"
+repo = "https://github.com/tyru/capture.vim"
 hooks_file = "$DEIN_RC_DIR/hooks/capture.lua"
 on_cmd = "Capture"
 
 [[plugins]]
-repo = "lewis6991/gitsigns.nvim"
+repo = "https://github.com/lewis6991/gitsigns.nvim"
 hooks_file = "$DEIN_RC_DIR/hooks/gitsigns.lua"
 if = "has('nvim')"
 on_event = ["BufRead", "BufNewFile"]
 
 [[plugins]]
-repo = "thinca/vim-qfreplace"
+repo = "https://github.com/thinca/vim-qfreplace"
 on_cmd = "Qfreplace"
 
 [[plugins]]
-repo = "rcarriga/nvim-notify"
+repo = "https://github.com/rcarriga/nvim-notify"
 hooks_file = "$DEIN_RC_DIR/hooks/nvim-notify.lua"
 if = "has('nvim')"
 
 [[plugins]]
-repo = "MunifTanjim/nui.nvim"
+repo = "https://github.com/MunifTanjim/nui.nvim"
 if = "has('nvim')"
 
 [[plugins]]
-repo = "folke/noice.nvim"
+repo = "https://github.com/folke/noice.nvim"
 hooks_file = "$DEIN_RC_DIR/hooks/noice.lua"
 depends = ["nui.nvim", "nvim-notify"]
 if = "has('nvim')"
@@ -600,7 +600,7 @@ on_event = [
 on_lua = "notify"
 
 [[plugins]]
-repo = "uga-rosa/ccc.nvim"
+repo = "https://github.com/uga-rosa/ccc.nvim"
 hooks_file = "$DEIN_RC_DIR/hooks/ccc.lua"
 on_event = ["BufRead", "BufNewFile"]
 if = "has('nvim')"
@@ -629,7 +629,7 @@ require("copilot").setup({
 if = "!exists('$COPILOT_DISABLE')"
 
 [[plugins]]
-repo = "CopilotC-Nvim/CopilotChat.nvim"
+repo = "https://github.com/CopilotC-Nvim/CopilotChat.nvim"
 lua_source = """
 require("CopilotChat").setup({
   help = false,


### PR DESCRIPTION
Execute `sd '^repo = "([^:/]+)\/(.+)"' 'repo = "https://github.com/$1/$2"' config/nvim/rc/*.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository URLs for various plugins to use full GitHub URLs instead of shorthand or non-HTTPS links. This ensures secure and accurate fetching of plugin resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->