### PR TITLE
docs: omit skhd from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I'm using several OSs.
 - Mac
     - OS: Mac (Apple Silicon)
     - WM: [yabai](https://github.com/koekeishiya/yabai)
-    - hotkeys: [skhd](https://github.com/koekeishiya/skhd), [karabiner-element](https://github.com/pqrs-org/Karabiner-Elements)
+    - hotkeys: [karabiner-element](https://github.com/pqrs-org/Karabiner-Elements)
     - Bar: [SketchyBar](https://github.com/FelixKratz/SketchyBar)
 - Windows
     - OS:( Windows10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the hotkeys section in the README for Mac OS, removing the `skhd` hotkey manager and simplifying the information to focus solely on `karabiner-element`.
	- Made a minor formatting correction in the Windows section for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->