### PR TITLE
chore: delete taplo

### DIFF
--- a/config/aqua/aqua.yaml
+++ b/config/aqua/aqua.yaml
@@ -46,7 +46,6 @@ packages:
 - name: docker/buildx@v0.24.0
 - name: crate-ci/typos@v1.32.0
 - name: hadolint/hadolint@v2.12.0
-- name: tamasfe/taplo/full@0.9.3
 - name: protocolbuffers/protobuf/protoc@v30.2
 - name: lsd-rs/lsd@v1.1.5
 - name: editorconfig-checker/editorconfig-checker@v3.3.0


### PR DESCRIPTION
it managed by nix already

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused package from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->